### PR TITLE
Add TodoList and AddTodoForm inside dialog triggered by FAB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@mui/icons-material": "^7.0.2",
         "@mui/material": "^7.0.2",
         "@mui/x-date-pickers": "^8.0.0",
         "date-fns": "^4.1.0",
@@ -368,6 +369,7 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -408,6 +410,7 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
       "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1102,10 +1105,37 @@
         "url": "https://opencollective.com/mui-org"
       }
     },
+    "node_modules/@mui/icons-material": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.0.2.tgz",
+      "integrity": "sha512-Bo57PFLOqXOqPNrXjd8AhzH5s6TCsNUQbvnQ0VKZ8D+lIlteqKnrk/O1luMJUc/BXONK7BfIdTdc7qOnXYbMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^7.0.2",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@mui/material": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.0.2.tgz",
       "integrity": "sha512-rjJlJ13+3LdLfobRplkXbjIFEIkn6LgpetgU/Cs3Xd8qINCCQK9qXQIjjQ6P0FXFTPFzEVMj0VgBR1mN+FhOcA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.0",
         "@mui/core-downloads-tracker": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@mui/icons-material": "^7.0.2",
     "@mui/material": "^7.0.2",
     "@mui/x-date-pickers": "^8.0.0",
     "date-fns": "^4.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,11 @@
-import AddTodoForm from "./components/features/todos/AddTodoForm";
+import Home from "./containers/Home";
 import MainLayout from "./layouts/MainLayout";
 
 
 function App() {
   return (
     <MainLayout>
-      <div>
-        <AddTodoForm />
-      </div>
+      <Home />
     </MainLayout>
   );
 }

--- a/src/components/features/todos/AddTodoForm.tsx
+++ b/src/components/features/todos/AddTodoForm.tsx
@@ -1,4 +1,3 @@
-
 import { TextField, Box, Button, Card, Typography } from '@mui/material';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { useState } from 'react';
@@ -77,8 +76,22 @@ const AddTodoForm = ({ addTodo }: AddTodoFormProps) => {
             textField: {
               fullWidth: true,
               margin: 'normal',
-              required: true,
+              required: true
             },
+            popper: {
+              sx: {
+                zIndex: 99999
+              },
+              placement: "bottom-start",
+              modifiers: [
+                {
+                  name: "offset",
+                  options: {
+                    offset: [0, 8]
+                  }
+                }
+              ]
+            }
           }}
         />
         {error && (

--- a/src/components/features/todos/AddTodoForm.tsx
+++ b/src/components/features/todos/AddTodoForm.tsx
@@ -3,11 +3,12 @@ import { TextField, Box, Button, Card, Typography } from '@mui/material';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { useState } from 'react';
 import { Todo } from '../../../types/todo';
-import useTodos from '../../../hooks/useTodos';
 
+interface AddTodoFormProps {
+  addTodo: (todo: Todo) => void;
+}
 
-const AddTodoForm = () => {
-  const { addTodo } = useTodos();
+const AddTodoForm = ({ addTodo }: AddTodoFormProps) => {
 
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');

--- a/src/components/features/todos/TodoItem.tsx
+++ b/src/components/features/todos/TodoItem.tsx
@@ -1,0 +1,73 @@
+import { ListItem, Checkbox, Typography, Box, IconButton } from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+import { TodoItemProps } from "../../../types/TodoItemProps";
+
+
+const TodoItem = ( prop: TodoItemProps  ) => {
+    const { todo, toggleComplete, deleteTodo } = prop;
+
+    const handleToggle = () => {
+        toggleComplete(todo.id);
+    };
+
+    const handleDelete = () => {
+        deleteTodo(todo.id);
+    };
+
+    return (
+        <ListItem
+          sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              borderBottom: '1px solid #eee',
+              py: 1,
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', flex: 1 }}>
+          <Checkbox
+            checked={todo.completed}
+            onChange={handleToggle}
+            
+          />
+            <Box sx={{ ml: 1 }}>
+              <Typography
+                variant="subtitle1"
+                sx={{
+                textDecoration: todo.completed ? 'line-through' : 'none',
+                color: todo.completed ? 'text.secondary' : 'text.primary',
+                }}
+              >
+                {todo.title}
+              </Typography>
+              {todo.description && (
+                <Typography
+                  variant="body2"
+                  sx={{
+                      color: todo.completed ? 'text.disabled' : 'text.secondary',
+                  }}
+                >
+                  {todo.description}
+                </Typography>
+              )}
+              <Typography variant="caption" color="text.secondary">
+                Deadline: {todo.deadline.toLocaleString()}
+              </Typography>
+            </Box>
+          </Box>
+
+          <Box>
+            <IconButton aria-label="Edit todo" onClick={() => { /* Edit action later */ }}>
+              <EditIcon />
+            </IconButton>
+            <IconButton aria-label="Delete todo" color="error" onClick={handleDelete}>
+              <DeleteIcon />
+            </IconButton>
+          </Box>
+        </ListItem>
+
+ );
+};
+
+export default TodoItem;

--- a/src/components/features/todos/TodoList.tsx
+++ b/src/components/features/todos/TodoList.tsx
@@ -1,0 +1,38 @@
+import { List, Typography } from "@mui/material";
+import TodoItem from "./TodoItem";
+import { Todo } from "../../../types/todo";
+
+interface TodoListProps {
+    todos: Todo[];
+    toggleComplete: (id: string) => void;
+    deleteTodo: (id: string) => void;
+}
+
+const TodoList = ({ todos, toggleComplete, deleteTodo }: TodoListProps) => {
+    if (!todos.length) {
+        return (
+            <Typography 
+                variant="body1" 
+                sx={{ color: 'text.secondary' }}
+                textAlign="center"
+            >
+                No todos available.
+            </Typography>
+        );
+    }
+
+    return (
+        <List>
+            {todos.map((todo) => (
+                <TodoItem 
+                    key={todo.id}
+                    todo={todo} 
+                    toggleComplete={toggleComplete} 
+                    deleteTodo={deleteTodo} 
+                />
+            ))}
+        </List>
+    );
+}
+
+export default TodoList;

--- a/src/containers/Home.tsx
+++ b/src/containers/Home.tsx
@@ -41,6 +41,21 @@ function Home() {
         onClose={() => setIsDialogOpen(false)}
         maxWidth="sm"
         fullWidth
+        sx={{
+          '& .MuiDialog-container': {
+            alignItems: 'flex-start',
+            paddingTop: '10vh'
+          }
+        }}
+        PaperProps={{
+          sx: {
+            position: 'relative',
+            overflow: 'visible',
+            '& .MuiPopover-root': {
+              zIndex: 9999
+            }
+          }
+        }}
       >
         <AddTodoForm addTodo={handleAddTodo} />
       </Dialog>

--- a/src/containers/Home.tsx
+++ b/src/containers/Home.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import AddTodoForm from "../components/features/todos/AddTodoForm";
+import TodoList from "../components/features/todos/TodoList";
+import useTodos from "../hooks/useTodos";
+import { Fab, Dialog } from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import { Todo } from "../types/todo";
+
+function Home() {
+  const { addTodo, todos, toggleComplete, deleteTodo } = useTodos();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const handleAddTodo = (todo: Todo) => {
+    addTodo(todo);
+    setIsDialogOpen(false);
+  };
+
+  return (
+    <div style={{ padding: "20px", position: "relative", minHeight: "calc(100vh - 64px)" }}>
+      <TodoList 
+        todos={todos} 
+        toggleComplete={toggleComplete} 
+        deleteTodo={deleteTodo} 
+      />
+      
+      <Fab 
+        color="primary" 
+        aria-label="add" 
+        onClick={() => setIsDialogOpen(true)}
+        sx={{
+          position: "fixed",
+          bottom: 24,
+          right: 24,
+        }}
+      >
+        <AddIcon />
+      </Fab>
+
+      <Dialog 
+        open={isDialogOpen} 
+        onClose={() => setIsDialogOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <AddTodoForm addTodo={handleAddTodo} />
+      </Dialog>
+    </div>
+  );
+}
+
+export default Home;

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,0 +1,24 @@
+import { ThemeProvider } from '@mui/material/styles';
+import { LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import AppBar from '@mui/material/AppBar';
+import Toolbar from "@mui/material/Toolbar";
+import Typography from "@mui/material/Typography";
+import theme from "../theme";
+
+const MainLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return (
+    <ThemeProvider theme={theme}>
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <AppBar position="static">
+          <Toolbar>
+            <Typography variant="h6">Todo App</Typography>
+          </Toolbar>
+        </AppBar>
+        {children}
+      </LocalizationProvider>
+    </ThemeProvider>
+  );
+};
+
+export default MainLayout;

--- a/src/types/TodoItemProps.ts
+++ b/src/types/TodoItemProps.ts
@@ -1,0 +1,7 @@
+import { Todo } from '../types/todo';
+
+export interface TodoItemProps {
+  todo: Todo;
+  toggleComplete: (id: string) => void;
+  deleteTodo: (id: string) => void;
+}


### PR DESCRIPTION
TodoList component:

Displays the list of todos using useTodos and Material UI’s List + TodoItem components.

Shows a message when no todos are available.

AddTodoForm inside a dialog:

A Floating Action Button (FAB) is now used to trigger a modal dialog.

The dialog contains the AddTodoForm, allowing users to create new todos.

New todos are connected to the shared state via useTodos.